### PR TITLE
New plugin design

### DIFF
--- a/src/main/scala/org/so/plugin/JoinOptimizer.scala
+++ b/src/main/scala/org/so/plugin/JoinOptimizer.scala
@@ -10,5 +10,5 @@ class JoinOptimizer(val global: Global) extends Plugin {
   override val description = "Optimize Spark joins for all actions"
   val analysisComponent = new AnalysisComponent(global, name)
   val rewriteComponent = new RewriteComponent(global, name)
-  override val components = List(analysisComponent, rewriteComponent)
+  override val components = List(rewriteComponent)
 }

--- a/src/main/scala/org/so/plugin/components/AnalysisComponent.scala
+++ b/src/main/scala/org/so/plugin/components/AnalysisComponent.scala
@@ -58,6 +58,13 @@ class AnalysisComponent(val global: Global, val phaseName: String) extends Plugi
     }
   }
 
+  /**
+    * Join analyzer is responsible for finding joins on RDD types and transforming the target RDDs (ones on either side
+    * of a join) by adding a map stage before calling join.
+    * @param lambda
+    * @param nextFunc
+    * @param joinCtx
+    */
   class JoinAnalyzer(val lambda: Tree,
                      val nextFunc: String,
                      val joinCtx: JoinContext) extends global.Transformer {
@@ -94,12 +101,18 @@ class AnalysisComponent(val global: Global, val phaseName: String) extends Plugi
     def getIndexFromAccessor(a : String): Int = a.split("_")(1).toInt
   }
 
+  /**
+    * Join context captures the outer body of join call. This information is used in various places
+    * to transform the tree with new types.
+    * @param joinReturnType
+    * @param joinBody
+    * @param pairRDDTags
+    */
   class JoinContext(val joinReturnType: List[Tree],
                     val joinBody: List[Tree],
                     val pairRDDTags: List[Tree]) {
 
     def getRDDTypes() : (List[Type], List[Type]) = {
-//      joinReturnType(1).tpe = List((Int, Int), (Int, Int))
       val joinValueReturnTypes = joinReturnType(1)
       (joinValueReturnTypes.tpe.typeArgs(0).typeArgs,
         joinValueReturnTypes.tpe.typeArgs(1).typeArgs)

--- a/src/main/scala/org/so/plugin/components/RewriteComponent.scala
+++ b/src/main/scala/org/so/plugin/components/RewriteComponent.scala
@@ -1,6 +1,7 @@
 package org.so.plugin.components
 
 
+import org.so.plugin.analysis.LambdaAnalyzer
 import scala.tools.nsc.Global
 import scala.tools.nsc.plugins.PluginComponent
 import scala.tools.nsc.transform.{Transform, TypingTransformers}
@@ -16,19 +17,54 @@ class RewriteComponent(val global: Global, val phaseName: String) extends Plugin
   with Transform {
   import global._
 
-  override val runsAfter: List[String] = List[String]("refchecks")
+  override val runsAfter: List[String] = List[String]("parser")
   override def newTransformer(unit: CompilationUnit) = new Transformer(unit)
-
+  val la = new LambdaAnalyzer(global)
   /**
-    * Traverses the AST generated right after "refchecks" phase and analyzes
+    * Traverses the AST generated right after "parser" phase and analyzes
     * usage of columns
-    * @param unit AST after "refchecks" phase of scala compiler
+    * @param unit AST after "parser" phase of scala compiler
     */
   class Transformer(unit: CompilationUnit)
     extends TypingTransformer(unit) {
-    override def transform(tree: Tree): Tree = {
-      println("REWRITE COMPONEENT", tree)
-      super.transform(tree)
+    override def transform(tree: Tree): Tree = tree match {
+      // Look for a join pattern
+      case a @ q"$x.join($y).$func[$ts]($lambda)" => {
+        try {
+          val usage = la.optimizeLambdaFn(lambda.asInstanceOf[la.global.Tree], func.toString)
+          var params1 = List[Tree]() // Stores the parameters for transformations on RDD1
+          var params2 = List[Tree]() // Stores the parameters for transformations on RDD2
+          for (i <- 22 to 1 by -1) {
+            params1 = getParamNode(usage._1, "a", i) :: params1
+            params2 = getParamNode(usage._2, "b", i) :: params2
+          }
+          // Build a tree for parameters of transformed mapValues functions on RDDs.
+          val rdd1Map = Apply(Select(Ident("scala"), TermName("Tuple22")), params1)
+          val rdd2Map = Apply(Select(Ident("scala"), TermName("Tuple22")), params2)
+          // Return the transformed tree
+          return q"$x.mapValues(a => $rdd1Map).join($y.mapValues(b => $rdd2Map)).$func[$ts]($lambda)"
+        } catch {
+          case e : Exception =>
+        }
+        a
+      }
+      case _ => super.transform(tree)
+    }
+
+    /**
+      * Given a usage lookup for an RDD's column, return Select node if a column is in the lookup,
+      * otherwise return Literal `null`
+      * @param usageLookup a set containing accessors on a RDD, depicting the columns used
+      * @param termName a dummy termname for the `Select` node
+      * @param i column number
+      * @return
+      */
+    def getParamNode(usageLookup: Set[String], termName: String, i : Int) : Tree = {
+      if (usageLookup.contains("_" + i))
+        Select(Ident(TermName(termName)), TermName("_"+i))
+      else
+        Literal(Constant(null))
+
     }
   }
 }

--- a/src/test/scala/org/so/plugin/BadMapSparkTest_1_NoTypeHint.scala
+++ b/src/test/scala/org/so/plugin/BadMapSparkTest_1_NoTypeHint.scala
@@ -1,0 +1,23 @@
+package test.scala.org.so.plugin
+
+import org.apache.spark.{SparkConf, SparkContext}
+
+/**
+  * @author Manthan Thakar
+  */
+class BadMapSparkTest_1_NoTypeHint {
+
+  def main(args: Array[String]) {
+    val conf = new SparkConf().setAppName("Bad Test 1")
+      .setMaster("local")
+    val sc = new SparkContext(conf)
+
+    val rdda = sc.parallelize(List((1, (1, 11)), (2, (2, 22))))
+    val rddb = sc.parallelize(List((1, (1, 11)), (2, (2, 22))))
+
+    rdda
+      .join(rddb)
+      .mapValues(x=> x._1._1 + x._2._2)
+      .collect()
+  }
+}


### PR DESCRIPTION
This version of the plugin works after the `parser` phase as opposed to `refchecks` in the previous version.

This makes our lives easier since we don't have to deal with huge type trees. Also, the ineffectiveness of `showRaw` didn't help in that case.